### PR TITLE
Updated docker-compose to work from app/design/frontend directory

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -13,8 +13,9 @@ services:
         - BASEPATH=${BASEPATH}
         - NODEJS_VERSION=${NODEJS_VERSION}
     volumes:
-      - ./src/localmodules/scandipwa-base-theme:/var/www/public
-    working_dir: "/var/www/public"
+      - ./src/app/design/frontend/Scandiweb/pwa:/var/www/public/app/design/frontend/Scandiweb/pwa
+      - ./src/vendor/scandipwa/source:/var/www/public/vendor/scandipwa/source
+    working_dir: "/var/www/public/app/design/frontend/Scandiweb/pwa/"
     env_file: .env
     expose:
       - 3003


### PR DESCRIPTION
This PR resolves the [issue #1](https://github.com/scandipwa/scandipwa-base/issues/1).

Updated the `docker-compose.frontend.yml` to match the app service. This is done to decrease the amount of difference between the default and non-frontend setup.

There are changes to `scandipwa/base-theme` pending. 