### PR TITLE
Keep varnish at 80, but override in SSL

### DIFF
--- a/deploy/local/env
+++ b/deploy/local/env
@@ -12,7 +12,7 @@ ELASTICSEARCH_VERSION=5.6.13
 RABBITMQ_VERSION=alpine
 
 # Service configurations (ENV)
-VARNISH_PORT=8080
+VARNISH_PORT=80
 # Varnish memory limit, defaults to 256m
 #VARNISH_MEMORY=512m
 NGINX_BIND_PORT=3031

--- a/docker-compose.ssl.yml
+++ b/docker-compose.ssl.yml
@@ -19,3 +19,6 @@ services:
     links:
       - nginx
       - varnish
+  varnish:
+    ports:
+      - 8080:80


### PR DESCRIPTION
This fixes the issue when Varnish is bound to 80 port and executed along with ssl container