### PR TITLE
Decoupling project version from env select, switching location

### DIFF
--- a/deploy/local/env
+++ b/deploy/local/env
@@ -27,6 +27,7 @@ MAILDEV_PORT=1080
 BASEPATH=/var/www/public
 THEMEPATH=app/design/frontend/Scandiweb/pwa
 PROJECT_TAG=local
+PROJECT_IMAGE=latest
 
 # PHP Composer uses plain version number, fail if not existing
 # version list, manual download section: https://getcomposer.org/download/

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -6,7 +6,7 @@ services:
     links:
       - frontend
   frontend:
-    image: scandipwa/frontend:${PROJECT_TAG}
+    image: scandipwa/frontend:${PROJECT_IMAGE}
     build:
       context: frontend
       args:

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -6,7 +6,7 @@ services:
     links:
       - frontend
   frontend:
-    image: registry.kube.indvp.com/scandipwa-oss/frontend:${PROJECT_TAG}
+    image: scandipwa/frontend:${PROJECT_TAG}
     build:
       context: frontend
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: registry.kube.indvp.com/scandipwa-oss/scandipwa-base:${PROJECT_TAG}
+    image: scandipwa/base:${PROJECT_IMAGE}
     build:
       context: .
       args:
@@ -31,7 +31,7 @@ services:
     command: ["/wait-for-it.sh", "mysql:3306", "--", "/start.sh"]
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
   varnish:
-    image: registry.kube.indvp.com/scandipwa-oss/varnish:5.1
+    image: scandipwa/varnish:latest
     build:
       context: varnish
     restart: on-failure:30

--- a/docs/D-xdebug.md
+++ b/docs/D-xdebug.md
@@ -2,8 +2,7 @@
 
 ## Setup
 
-php with xdebug is set for local by default, through $PHP_VERSION variable by appending `-debug` to docker image 
-version.
+php with xdebug is can be set for local, by changing  $PROJECT_IMAGE variable to `xdebug`, ensuring corrent docker image to be used.
 
 ### PhpStorm configuration
 


### PR DESCRIPTION
Also using separate variable for selecting base image, without affecting internal application deployment.

Closes #10 and improves #12 