### PR TITLE
Added entry-points to all new front-end container interface

### DIFF
--- a/docker-compose.core.yml
+++ b/docker-compose.core.yml
@@ -14,10 +14,7 @@ services:
         - NODEJS_VERSION=${NODEJS_VERSION}
     volumes:
       - ./src/localmodules/base-theme:/var/www/public
-    entrypoint:
-      - npm
-      - run
-      - dev-server-core
+    command: ["npm", "run", "dev-server-core"]
     working_dir: "/var/www/public"
     env_file: .env
     command: ["/bin/bash", "/start-core.sh"]

--- a/docker-compose.core.yml
+++ b/docker-compose.core.yml
@@ -14,6 +14,10 @@ services:
         - NODEJS_VERSION=${NODEJS_VERSION}
     volumes:
       - ./src/localmodules/base-theme:/var/www/public
+    entrypoint:
+      - npm
+      - run
+      - dev-server-core
     working_dir: "/var/www/public"
     env_file: .env
     command: ["/bin/bash", "/start-core.sh"]

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -15,10 +15,7 @@ services:
     volumes:
       - ./src/app/design/frontend/Scandiweb/pwa:/var/www/public/app/design/frontend/Scandiweb/pwa
       - ./src/vendor/scandipwa/source:/var/www/public/vendor/scandipwa/source
-    entrypoint:
-      - npm
-      - run
-      - pm2-watch
+    command: ["npm", "run", "pm2-watch"]
     working_dir: "/var/www/public/app/design/frontend/Scandiweb/pwa/"
     env_file: .env
     expose:

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -15,6 +15,10 @@ services:
     volumes:
       - ./src/app/design/frontend/Scandiweb/pwa:/var/www/public/app/design/frontend/Scandiweb/pwa
       - ./src/vendor/scandipwa/source:/var/www/public/vendor/scandipwa/source
+    entrypoint:
+      - npm
+      - run
+      - pm2-watch
     working_dir: "/var/www/public/app/design/frontend/Scandiweb/pwa/"
     env_file: .env
     expose:


### PR DESCRIPTION
The scripts were added here, to override default behavior of running `npm ci && npm run watch`, this is done in docker-compose configuration file in order to separate core and default behavior. 

> Notice, now the `npm ci` is not run on FE container startup, which might (and will) cause issues while setting up initially

However, afterwards, it saves a lot of time, especially when developing theme, by cutting time on not executing CI on every container initialization. I think, this is now the best solution, but because the dependencies are very rare to be updated this might be an improvement. Please @eli-l notify me, if the `npm ci` has to be brought back.

Notice the difference between dev and core processes:
- Core is running only webpack configuration file watch (there is nowhere to fallback)
- Default is running PM2 with two processes: the configuration watch and the .js/.scss creation / deletion watch 