### PR TITLE
SWPWA-494 - Fix for certain search terms returning a 502 error

### DIFF
--- a/deploy/shared/conf/nginx/magento.conf
+++ b/deploy/shared/conf/nginx/magento.conf
@@ -122,7 +122,8 @@ server {
   location ~ (index|get|static|report|404|503|health_check)\.php$ {
       try_files $uri =404;
       fastcgi_pass   fastcgi_backend;
-      fastcgi_buffers 1024 4k;
+      fastcgi_buffers 16 16k;
+      fastcgi_buffer_size 32k;
 
       fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
       fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";


### PR DESCRIPTION
Fixed that certain search terms (i.e dark blue, dark blue slim, grey slim, blue slim etc.) return a 502 error from the server.