### PR TITLE
fix core volume mounting

### DIFF
--- a/docker-compose.core.yml
+++ b/docker-compose.core.yml
@@ -12,7 +12,7 @@ services:
       args:
         - NODEJS_VERSION=${NODEJS_VERSION}
     volumes:
-      - .src:/var/www/public
+      - ./src:/var/www/public
       # Uncomment line below only for testing launch script without rebuild
       # - ./build/frontend/start.sh:/start.sh
     env_file: .env


### PR DESCRIPTION
Frontend container wont start without this piece on Linux when using core docker-compose file