### PR TITLE
Fix for "Upstream sent too big header" error

### DIFF
--- a/deploy/frontend/conf/nginx/cache-router.conf
+++ b/deploy/frontend/conf/nginx/cache-router.conf
@@ -15,6 +15,9 @@ server {
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_redirect off;
     proxy_read_timeout 600s;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
   }
 
   location ~* /graphql {
@@ -24,6 +27,9 @@ server {
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_redirect off;
     proxy_read_timeout 600s;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
   }
 
     location ~* /rest {
@@ -33,6 +39,9 @@ server {
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
       proxy_redirect off;
       proxy_read_timeout 600s;
+      proxy_buffer_size 128k;
+      proxy_buffers 4 256k;
+      proxy_busy_buffers_size 256k;
     }
 
   location ~* /(static|media|admin) {
@@ -42,5 +51,8 @@ server {
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_redirect off;
     proxy_read_timeout 600s;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
   }
 }

--- a/deploy/shared/conf/nginx/cache-router.conf
+++ b/deploy/shared/conf/nginx/cache-router.conf
@@ -21,6 +21,9 @@ server {
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_redirect off;
     proxy_read_timeout 600s;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
 
     if ($prerender = 1) {
       proxy_pass http://rendertron:8083/render/https://$host$request_uri;

--- a/deploy/shared/conf/nginx/magento.conf
+++ b/deploy/shared/conf/nginx/magento.conf
@@ -75,7 +75,7 @@ server {
       }
       add_header X-Frame-Options "SAMEORIGIN";
   }
-  
+
   location /.well-known/ {
       try_files $uri $uri/ =404;
   }

--- a/deploy/shared/conf/nginx/ssl-terminator.conf
+++ b/deploy/shared/conf/nginx/ssl-terminator.conf
@@ -40,5 +40,8 @@ server {
     proxy_pass_header Sec-Websocket-Extensions;
     proxy_redirect off;
     proxy_read_timeout 600s;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
   }
 }


### PR DESCRIPTION
Fix for error "Upstream sent too big header while reading response header from upstream"

Fix idea taken from https://magento.stackexchange.com/questions/268896/upstream-sent-too-big-header-while-reading-response-header-from-upstream