### PR TITLE
Added msmtp intallation command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,12 @@ COPY deploy/shared/conf/php/docker-php-fpm.conf /usr/local/etc/php-fpm.d/docker.
 COPY deploy/wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh
 
+# Install MSMTP
+RUN apt-get update; \
+    apt-get install -y \
+        msmtp \
+        msmtp-mta
+
 # MSMTP config set
 RUN { \
         echo 'defaults'; \


### PR DESCRIPTION
Fixes scandipwa/base-theme#1665

According to configs, mail sending should be handled by `msmtp`.
But i isn't installed in the container.
Also php tries to execute `sendmail` command, when `mail()` function is being called.

`msmtp` and `msmtp-mta` packages adds all necessary, including `sendmail`.

Checked this by creating a new custom Dockerfile extended from `scandipwa/base`.
Mail was sent and intercepted by `maildev`.